### PR TITLE
Move data-wp-router-region to the root

### DIFF
--- a/src/render.php
+++ b/src/render.php
@@ -18,41 +18,39 @@ $currency = get_woocommerce_currency_symbol( get_woocommerce_currency() );
 
 ?>
 
-<div data-wp-interactive="workshop" class="pc-workshop-block">
-	<div data-wp-router-region="workshop-loop">
-		<ul class="products display-as-<?= $attributes['layout'] ?>">
-			<?php foreach ($products as $product) {
-				$data = $product->get_data();
+<div data-wp-interactive="workshop" data-wp-router-region="workshop-loop" class="pc-workshop-block">
+	<ul class="products display-as-<?= $attributes['layout'] ?>">
+		<?php foreach ($products as $product) {
+			$data = $product->get_data();
+		?>
+			<li class="product">
+				<article>
+					<img
+						class="product__img"
+						src="<?= wp_get_attachment_url( $data['image_id'] ); ?>"
+					/>
+					<h1 class="product__name"><?= $data['name']; ?></h1>
+					<div class="product__details">
+						<span class="product__price"><?= $currency . $data['price']; ?></span>
+					</div>
+				</article>
+			</li>
+		<?php } ?>
+	</ul>
+	<nav>
+		<ul class="pagination">
+			<?php for ($i = 1; $i <= $max_num_pages; $i++) {
+				$is_active = $i === $page_number;
 			?>
-				<li class="product">
-					<article>
-						<img
-							class="product__img"
-							src="<?= wp_get_attachment_url( $data['image_id'] ); ?>"
-						/>
-						<h1 class="product__name"><?= $data['name']; ?></h1>
-						<div class="product__details">
-							<span class="product__price"><?= $currency . $data['price']; ?></span>
-						</div>
-					</article>
+				<li class="pagination__page">
+					<?php if ($is_active) : ?>
+						<span class="pagination__page--is-active"><?= $i; ?></span>
+					<?php else : ?>
+						<a class="pagination__page--link" data-wp-on--click="actions.navigate" href="?page_num=<?= $i; ?>"><?= $i; ?></a>
+					<?php endif; ?>
 				</li>
 			<?php } ?>
 		</ul>
-		<nav>
-			<ul class="pagination">
-				<?php for ($i = 1; $i <= $max_num_pages; $i++) {
-					$is_active = $i === $page_number;
-				?>
-					<li class="pagination__page">
-						<?php if ($is_active) : ?>
-							<span class="pagination__page--is-active"><?= $i; ?></span>
-						<?php else : ?>
-							<a class="pagination__page--link" data-wp-on--click="actions.navigate" href="?page_num=<?= $i; ?>"><?= $i; ?></a>
-						<?php endif; ?>
-					</li>
-				<?php } ?>
-			</ul>
-		</nav>
-	</div>
+	</nav>
 </div>
 


### PR DESCRIPTION
Fixes the problem with the navigation not working the second time a link is clicked.

From [the docs]([https://github.com/WordPress/gutenberg/tree/trunk/packages/interactivity-router#data-wp-router-region]()):

> `data-wp-router-region` defines a region that is updated on navigation. It requires a unique ID as the value and can only be used in root interactive elements, i.e., elements with `data-wp-interactive` that are not nested inside other elements with `data-wp-interactive`.



